### PR TITLE
Point installation script to latest binary release.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ error() {
 main() {
 	BIN_PATH="$HOME/.local/bin";
 	BIN_NAME="gptc";
-	URL="https://github.com/dmosc/gptc/releases/download/alpha/gptc";
+	URL="https://github.com/dmosc/gptc/releases/latest/download/gptc";
 
 	# If $BIN_PATH is not included in the main $PATH
 	# we add it to make sure the binary is findable.


### PR DESCRIPTION
## Description

Force `scripts/install.sh` to download gptc's latest binary release.

## Tasks

- Change pointing URL

## Resources and screenshots (optional)

- [Referencing the latest release.](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases)

## Triggers

closes #11 
