### PR TITLE
Change read input variable to lowercase to avoid conflicts with env vars.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,10 +41,10 @@ main() {
 		echo "export PATH=\"\$PATH:$BIN_PATH\"" >> $SHELL_PROFILE;
 	fi
 
-	if [[ -z ${OPENAI_KEY} ]]; then
-		read -p "Enter your OpenAI's API key: " OPENAI_KEY;
+	if [[ -n "${OPENAI_KEY}" ]]; then
+		read -p "Enter your OpenAI's API key: " openai_key;
 		message "Adding \$OPENAI_KEY to $SHELL_PROFILE config file with the provided API key.";
-		echo "export OPENAI_KEY=$OPENAI_KEY" >> $SHELL_PROFILE;
+		echo "export OPENAI_KEY=$openai_key" >> $SHELL_PROFILE;
 	fi
 
 	message "Ensuring $BIN_PATH exists";


### PR DESCRIPTION
## Description

Lower case read input variable to avoid conflicts with environment variables.

## Tasks

- Refactor variable `OPENAI_KEY` -> `openai_key`.
