### PR TITLE
Redirect stdout/stderr output back to controlling terminal.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,8 +41,10 @@ main() {
 		echo "export PATH=\"\$PATH:$BIN_PATH\"" >> $SHELL_PROFILE;
 	fi
 
-	if [[ -n "${OPENAI_KEY}" ]]; then
-		read -p "Enter your OpenAI's API key: " openai_key;
+	if [[ -z ${OPENAI_KEY} ]]; then
+		# See https://stackoverflow.com/a/15185051/11672866 for more information on
+		# stdout/stderr redirection.
+		read -p "Enter your OpenAI's API key: " openai_key < /dev/tty;
 		message "Adding \$OPENAI_KEY to $SHELL_PROFILE config file with the provided API key.";
 		echo "export OPENAI_KEY=$openai_key" >> $SHELL_PROFILE;
 	fi


### PR DESCRIPTION
## Description

Fix bash's `read` prompt execution when downloading the script via `curl`. When piping a `curl` request, the controlling terminal loses input/output controls and won't ask the user for the input.

## Tasks

- Redirect input/ouput back to controlling terminal with `< /dev/tty` redirect.
-

## Resources and screenshots (optional)

- [Read more.](https://stackoverflow.com/a/15185051/11672866)
