### PR TITLE
Add `update.sh` script to auto update binary version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ curl -fsSL https://raw.githubusercontent.com/dmosc/gptc/main/scripts/install.sh 
 
 During installation, `gptc` will prompt you for an OpenAI API key and export the `$OPENAI_KEY` environment variable inside your shell configuration file (i.e. `.zshrc`, `.bashrc`) with the provided key. The script installs `gptc`'s binary inside `/usr/local/bin` and appends the path to your `$PATH` variable if it isn't registered [(get an API key from OpenAI's platform)](https://platform.openai.com/account/api-keys).
 
+### Updated to latest version
+
+Run the following script to download `gptc`'s latest binary:
+
+```
+curl -fsSL https://raw.githubusercontent.com/dmosc/gptc/main/scripts/update.sh | sh
+```
+
+If all goes well you should have the freshest `gptc` version...
+
 ## Usage
 
 ```

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m';
+BLUE="\033[0;34m";
+YELLOW="\033[1;33m";
+NO_COLOR="\033[0m";
+
+info() {
+	echo "${YELLOW}[info]: $@${NO_COLOR}";
+}
+
+message() {
+	echo "${BLUE}[message]: $@${NO_COLOR}";
+}
+
+error() {
+	echo "${RED}[error]: $@${NO_COLOR}";
+	exit 1;
+}
+
+main() {
+	BIN_PATH="/usr/local/bin";
+	BIN_NAME="gptc";
+	URL="https://github.com/dmosc/gptc/releases/latest/download/gptc";
+
+	if [[ -e "$BIN_PATH/$BIN_NAME" ]]; then
+		curl -fsSL -o /tmp/gptc $URL;
+		mv /tmp/gptc "$BIN_PATH/$BIN_NAME";
+		chmod +x "$BIN_PATH/$BIN_NAME";
+		message "Finished updating gptc binary to the latest version.";
+		info "Try gptc --help for more information.";
+		exec $SHELL;
+	else
+		message "gptc is not installed on this computer.";
+		info "Try instead running: curl -fsSL https://raw.githubusercontent.com/dmosc/gptc/main/scripts/install.sh | sh";
+	fi
+}
+
+main || exit 1;


### PR DESCRIPTION
## Description

Introduce `scripts/update.sh` script to remotely update local binary to the latest version.

## Tasks

- Implement `scripts/update.sh` script.

## Resources and screenshots (optional)

- Cool to note that I generated this script using my `gptc` CLI.

## Triggers

closes #21 
