### PR TITLE
Add cross compile support to Linux and Windows OS with x86_64 archs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
+target*
 *.env
 *cache*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,20 @@
+pipeline {
+  agent any
+  stages {
+    stage('check deps') {
+      steps {
+        sh 'cargo --version'
+      }
+    }
+    stage('compile') {
+      steps {
+        sh 'cargo build'
+      }
+    }
+    stage('run with cargo') {
+      steps {
+        sh 'cargo run'
+      }
+    }
+  }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,7 +21,17 @@ error() {
 main() {
 	BIN_PATH="/usr/local/bin";
 	BIN_NAME="gptc";
-	URL="https://github.com/dmosc/gptc/releases/latest/download/gptc";
+	OS=$(uname -s);
+	ARCH=$(uname -m);
+	URL="https://github.com/dmosc/gptc/releases/latest/download/gptc-$OS-$ARCH";
+
+	if [[ $OS != *"Linux"* || $OS != *"Darwin"* || $OS != *"Windows"* ]]; then
+		error "Unsupported operating system: $OS";
+	fi
+
+	if [[ $ARCH != *"x86_64"* || $ARCH != *"arm64"* || $ARCH != *"aarch64"* ]]; then
+		error "Unsupported architecture: $ARCH";
+	fi
 
 	if [[ $SHELL == *"/zsh" ]]; then
 		SHELL_PROFILE="$HOME/.zshrc";

--- a/x86_64-linux.Dockerfile
+++ b/x86_64-linux.Dockerfile
@@ -1,0 +1,11 @@
+FROM amd64/rust:latest
+
+WORKDIR /app
+COPY . .
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+RUN rm -rf /var/lib/apt/lists/*
+RUN cargo install --path .
+ENV CARGO_TARGET_DIR=target.x86_64-linux
+CMD ["cargo", "build", "--release"]

--- a/x86_64-windows.Dockerfile
+++ b/x86_64-windows.Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:latest
+
+WORKDIR /app
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y g++-mingw-w64-x86-64
+RUN rustup target add x86_64-pc-windows-gnu
+RUN rustup toolchain install stable-x86_64-pc-windows-gnu
+ENV CARGO_TARGET_DIR=target/target.x86_64-windows
+CMD ["cargo", "build", "--release", "--target", "x86_64-pc-windows-gnu"]


### PR DESCRIPTION
## Description

Add support for native compilation of `gptc` in both Linux and Windows environments with x86_64 architectures.

## Tasks

- Implement Dockerfiles with compilation steps for each architecture.
- Update `install.sh` and `update.sh` scripts to download a binary based on the $OS-$ARCH pair.

## Resources and screenshots (optional)

- [Official Rust images in Docker hub](https://hub.docker.com/_/rust).
- [Docker-supported architectures](https://github.com/docker-library/official-images#architectures-other-than-amd64).
- [Cross-compilation with Docker images](https://kerkour.com/rust-reproducible-cross-compilation-with-docker).
- [`rust-cross`](https://github.com/japaric/rust-cross#i-want-to-build-binaries-for-linux-mac-and-windows-how-do-i-cross-compile-from-linux-to-mac) (all about Rust cross-compilation).
- [`cross`: zero setup cross compilation of Rust crates](https://github.com/cross-rs/cross) (didn't get it to work).
- [Ubuntu support packages browser](https://packages.ubuntu.com/). The `x86_64` arch image required some additional packages to be installed before building `gptc` binary: `g++-aarch64-linux-gnu` `libc6-dev-arm64-cross` `libxcb1-dev` `libxcb-render0-dev` `libxcb-shape0-dev` `libxcb-xfixes0-dev`.
  - https://github.com/orhun/kmon/issues/2 
  - https://github.com/nannou-org/nannou/issues/790

## Triggers

closes #32 
