### PR TITLE
Refactor build workflow trigger to non-build branches.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,22 @@ name: "Build distributions for major OS"
 
 # Specifies the trigger for the workflow.
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
-      - main
+      - "!builds-*"
 
 # Defines the build and upload jobs for the gptc application.
 jobs:
+  if_merged:
+    if: github.event.pull_request.merged
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo The PR was merged
+
   build_binaries:
     # Runs the job on the specified operating system using a matrix.
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Description

Only run `build.yml` on PRs from non-build branches.

## Tasks

- Change `on:` rule.
