### PR TITLE
Remove forgotten debug commands.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,8 +93,6 @@ jobs:
 
           # Switches to a new branch for the pull request.
           PR_BRANCH="build-$GITHUB_REF_NAME-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
-          ls -lha
-          echo $PR_BRANCH
           git switch -c $PR_BRANCH
           rsync -ar gptc-*-latest dist
           rm -rf gptc-*-latest


### PR DESCRIPTION
## Description

Left some debug commands inside `.github/workflows/build.yml` that weren't meant to be left.

## Tasks

- Fix workflow by removing unnecessary commands.
