### PR TITLE
Add support libs for Linux distros.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           if [ "$RUNNER_OS" = "Linux" ]; then
             echo "Building for Linux."
             sudo apt update
-            sudo apt install -y libxcb-shape0-dev libxcb-xfixes0-dev
+            sudo apt install -y libxcb-shape0 libxcb-xfixes0 libxcb-xinput0 libxcb-render0 libxcb-shape0 libc6
           elif [ "$RUNNER_OS" = "Windows" ]; then
             echo "Building for Windows."
             # choco install -y xcb-shape xcb-util-wm


### PR DESCRIPTION
## Description

These libraries seem to be needed to allow gptc to work in Linux distros.

## Tasks

- Add support libs.