### PR TITLE
Fix host runners instead of using "-latest" tag builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Specifies the latest version of Windows to use for the build.
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-20.04", "macos-12", "windows-2022"]
 
     steps:
       # Checks out the repository.
@@ -29,6 +29,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             echo "Building for Linux."
+            ldd --version
             sudo apt update
             sudo apt install -y libxcb-shape0 libxcb-xfixes0 libxcb-xinput0 libxcb-render0 libxcb-shape0 libc6
           elif [ "$RUNNER_OS" = "Windows" ]; then
@@ -146,9 +147,9 @@ jobs:
 
           # Copy binaries into a temporary location to avoid name conflicts.
           TMP_DIST=$(mktemp -d)
-          cp dist/gptc-ubuntu-latest/gptc "$TMP_DIST/gptc-ubuntu-latest"
-          cp dist/gptc-macos-latest/gptc "$TMP_DIST/gptc-macos-latest"
-          cp dist/gptc-windows-latest/gptc.exe "$TMP_DIST/gptc-windows-latest.exe"
+          cp dist/gptc-ubuntu-20.04/gptc "$TMP_DIST/gptc-ubuntu-20.04"
+          cp dist/gptc-macos-12/gptc "$TMP_DIST/gptc-macos-12"
+          cp dist/gptc-windows-2022/gptc.exe "$TMP_DIST/gptc-windows-2022.exe"
 
           # Create tag and upload binaries as artifacts.
           gh release create \


### PR DESCRIPTION
## Description

Set concrete host runners.

## Tasks

- Downgrade from `ubuntu-22.04` (also "latest") to `ubuntu-20.04` to downgrade `glibc` since the version included with `ubuntu-latest` seems to be very new to most hosts (GLIBC_2.34).

## Resources and screenshots (optional)

- [Stackoverflow convo on glibc](https://stackoverflow.com/questions/65120136/lib64-libc-so-6-version-glibc-2-32-not-found).
- [Github host runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).
