### PR TITLE
Remove ASCII escape characters since they aren't compatible on most OS shells.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
 
-RED='\033[0;31m';
-BLUE="\033[0;34m";
-YELLOW="\033[1;33m";
-NO_COLOR="\033[0m";
-
 info() {
-	echo "${YELLOW}[info]: $@${NO_COLOR}";
+	echo "[info]: $@";
 }
 
 message() {
-	echo "${BLUE}[message]: $@${NO_COLOR}";
+	echo "[message]: $@";
 }
 
 error() {
-	echo "${RED}[error]: $@${NO_COLOR}";
+	echo "[error]: $@";
 	exit 1;
 }
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
 
-RED='\033[0;31m';
-BLUE="\033[0;34m";
-YELLOW="\033[1;33m";
-NO_COLOR="\033[0m";
-
 info() {
-	echo "${YELLOW}[info]: $@${NO_COLOR}";
+	echo "[info]: $@";
 }
 
 message() {
-	echo "${BLUE}[message]: $@${NO_COLOR}";
+	echo "[message]: $@";
 }
 
 error() {
-	echo "${RED}[error]: $@${NO_COLOR}";
+	echo "[error]: $@";
 	exit 1;
 }
 


### PR DESCRIPTION
## Description

ASCII escape characters won't render correctly in Windows environments.

## Tasks

- Remove escape characters from install and 
-
