### PR TITLE
feat: Add warning for OpenAI quota exhaustion and exit gracefully

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -7,3 +7,7 @@ pub fn log(contents: &str) {
 pub fn info(contents: &str) {
     println!("{} {}", "[info]:".blue().bold(), contents.blue().bold());
 }
+
+pub fn warn(contents: &str) {
+    println!("{} {}", "[warn]:".yellow().bold(), contents.yellow().bold());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,25 +22,20 @@ async fn main() -> reqwest_middleware::Result<()> {
                 logger::info("Exiting due to OpenAI API quota/rate limit issue.");
                 process::exit(0);
             }
-
             let reply = response_val.as_object().unwrap()["choices"][0]["text"]
                 .as_str()
                 .unwrap()
                 .trim();
-
             if reply.is_empty() {
                 logger::info("no reply back; try a different wording for the query");
                 process::exit(0);
             }
-
             logger::info("fetched the following:");
-
             for line in reply.lines() {
                 if line.len() > 0 {
                     logger::log(line);
                 }
             }
-
             if args.clipboard {
                 let mut clipboard_context = clipboard::ClipboardContext::new().unwrap();
                 clipboard_context.set_contents(reply.to_string()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,29 +14,40 @@ async fn main() -> reqwest_middleware::Result<()> {
     let args = args::load_args();
     let config = config::Config::new().unwrap();
     let gpt_client = gpt_client::GPTClient::new();
-    let response = gpt_client.async_query(&args, &config).await?;
-    let reply = response.as_object().unwrap()["choices"][0]["text"]
-        .as_str()
-        .unwrap()
-        .trim();
+    let query_result = gpt_client.async_query(&args, &config).await;
 
-    if reply.is_empty() {
-        logger::info("no reply back; try a different wording for the query");
-        process::exit(0);
-    }
+    match query_result {
+        Ok(response_val) => {
+            if response_val.is_null() {
+                logger::info("Exiting due to OpenAI API quota/rate limit issue.");
+                process::exit(0);
+            }
 
-    logger::info("fetched the following:");
+            let reply = response_val.as_object().unwrap()["choices"][0]["text"]
+                .as_str()
+                .unwrap()
+                .trim();
 
-    for line in reply.lines() {
-        if line.len() > 0 {
-            logger::log(line);
+            if reply.is_empty() {
+                logger::info("no reply back; try a different wording for the query");
+                process::exit(0);
+            }
+
+            logger::info("fetched the following:");
+
+            for line in reply.lines() {
+                if line.len() > 0 {
+                    logger::log(line);
+                }
+            }
+
+            if args.clipboard {
+                let mut clipboard_context = clipboard::ClipboardContext::new().unwrap();
+                clipboard_context.set_contents(reply.to_string()).unwrap();
+                logger::info("copied contents to clipboard");
+            }
         }
-    }
-
-    if args.clipboard {
-        let mut clipboard_context = clipboard::ClipboardContext::new().unwrap();
-        clipboard_context.set_contents(reply.to_string()).unwrap();
-        logger::info("copied contents to clipboard");
+        Err(e) => return Err(e.into()),
     }
 
     Ok(())


### PR DESCRIPTION
Instead of crashing, the application now detects potential OpenAI API quota exhaustion errors (specifically, a 429 status code).

When such an error is detected:
1. A warning message is logged to the console (e.g., "You may have exceeded your OpenAI API quota or rate limit. Please check your OpenAI account.").
2. The application then prints an informational message and exits gracefully.

This was achieved by:
- Adding a `logger::warn` function for warning messages.
- Modifying `gpt_client::async_query` to check for the 429 status code. If detected, it logs the warning and returns `Ok(serde_json::Value::Null)`.
- Updating `main` to check for this `Null` value and exit cleanly if it's received.

closes #33
